### PR TITLE
Fix FMP update failure on systems with stale clocks

### DIFF
--- a/fmp/fmp.js
+++ b/fmp/fmp.js
@@ -229,7 +229,8 @@ function unpackPackage(filename) {
 			fs.mkdir(updateDir, function(err) {
 				if(err) { return deferred.reject(err); }
 				// Unpack the actual file into the newly created directory
-				child_process.exec('tar -xzf ' + path.resolve(filename), {cwd : updateDir}, function(err, stdout, stderr) {
+				// -m (--touch) prevents future-timestamp warnings that can overflow maxBuffer on clock-skewed systems
+				child_process.exec('tar -xzmf ' + path.resolve(filename), {cwd : updateDir, maxBuffer: 10 * 1024 * 1024}, function(err, stdout, stderr) {
 					if(err) { return deferred.reject(err); }
 					deferred.resolve(path.resolve(updateDir, 'manifest.json'));
 				});

--- a/fmp/fmp_operations.js
+++ b/fmp/fmp_operations.js
@@ -11,16 +11,21 @@ const log = require('../log').logger('fmp');
 const ensureDir = Q.nfbind(fs.ensureDir);
 
 // Return the expand command that is appropriate for the provided file, based on its file extension
+// The -m (--touch) flag prevents tar from setting file timestamps from the archive.
+// This is critical on systems without a battery-backed RTC (like Raspberry Pi) where the
+// system clock may be behind — without -m, tar emits a warning per file with a "future"
+// timestamp, which can overflow child_process.exec's maxBuffer and kill the extraction
+// mid-way, leaving a half-installed update.
 //   path - Full path to the file to check
 const getExpandCommand = function(path) {
     if (path.match(/.tar$/i)) {
-        return 'tar -xf ';
+        return 'tar -xmf ';
     }
     if (path.match(/.tar.gz$/i) || path.match(/.tgz$/i)) {
-        return 'tar -xzf ';
+        return 'tar -xzmf ';
     }
     if (path.match(/.tar.bz2?$/i)) {
-        return 'tar -xjf ';
+        return 'tar -xjmf ';
     }
     throw new Error(path + ' is an unknown archive type.');
 };
@@ -98,7 +103,7 @@ async function expandArchive(operation) {
     const sourceFile = resolveCwdPath(operation.cwd, operation.src);
 
     log.info('Expanding archive ' + sourceFile + ' to ' + operation.dest);
-    await Q.nfcall(child_process.exec, expandCommand + sourceFile, { cwd: operation.dest });
+    await Q.nfcall(child_process.exec, expandCommand + sourceFile, { cwd: operation.dest, maxBuffer: 10 * 1024 * 1024 });
 }
 
 // Install the firmware specified by `src`


### PR DESCRIPTION
On Raspberry Pis without a battery-backed RTC, the system clock can fall behind when offline. When an FMP update contains files with timestamps ahead of the system clock, tar emits a warning per file to stderr. With hundreds of files this overflows the default 1MB maxBuffer of child_process.exec, causing Node to kill the tar process mid-extraction — leaving a half-installed, broken engine.

Two fixes:
- Add -m (--touch) flag to all tar commands so extracted files get the current system time instead of archive timestamps, eliminating the warnings entirely
- Increase maxBuffer to 10MB as a safety net